### PR TITLE
Refactor C API, Improve CMake Integration, and Provide Usage Example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,11 @@ include_directories(${JINJA2CPP_INCLUDE_DIR})
 add_library(jinja2cppwrapper SHARED)
 
 file(GLOB_RECURSE SOURCES src/*.cpp)
+
 target_sources(jinja2cppwrapper PRIVATE ${SOURCES})
 
 target_link_libraries(jinja2cppwrapper PRIVATE ${JINJA2CPP_LIBRARY})
 
 install(TARGETS jinja2cppwrapper LIBRARY DESTINATION lib)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include/jinja2cppwrapper)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,26 @@ cmake --build . --parallel ${nproc}
 After building, you can install Jinja2C using:
 
 ```
-cmake --build .
+cmake --install .
 ```
 
-By default, this will install Jinja2C in `/usr/local/`. You can change the installation prefix by adding `-DCMAKE_INSTALL_PREFIX=/your/install/path` to the cmake command.
+By default, this will install Jinja2C in `/usr/local/` and headers in `/usr/local/include/jinja2cppwrapper`. You can change the installation prefix by adding `-DCMAKE_INSTALL_PREFIX=/your/install/path` to the cmake command.
+
+# Usage
+
+To use **jinja2cppwrapper** in your C project, include `jinja2cpp_wrap.h` and link against `ljinja2cppwrapper`.
+
+## Example
+
+The following example from `examples/` demonstrates how to compile a program using **jinja2cppwrapper**:
+
+```sh
+g++ -std=c++14 -o simple_example simple_example.c -I/path/to/include -L/path/to/lib -ljinja2cppwrapper
+```
+
+### Notes:
+- Replace `/path/to/include` with the directory where the header files are installed.
+- Replace `/path/to/lib` with the directory where the compiled library is located.
+
+
+

--- a/examples/simple_example.c
+++ b/examples/simple_example.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include "jinja2cppwrapper/jinja2cpp_wrap.h"
+
+int main() {
+    const char* source =
+        "{{ (\"Hello\", 'world') | join }}!!!\n"
+        "{{ (\"Hello\", 'world') | join(', ') }}!!!\n"
+        "{{ (\"Hello\", 'world') | join(d = '; ') }}!!!\n"
+        "{{ (\"Hello\", 'world') | join(d = '; ') | lower }}!!!\n";
+
+    jinja2cpp_template_t* tmpl = jinja2cpp_template_create();
+    if (!tmpl) {
+        fprintf(stderr, "Failed to create template\n");
+        return 1;
+    }
+
+    jinja2cpp_result_void_t* result = jinja2cpp_load(tmpl, source, "simple_example");
+    if (!jinja2cpp_result_has_value_void(result)) {
+        const jinja2cpp_error_info_t* error_info = jinja2cpp_result_error_void(result);
+        fprintf(stderr, "%s", jinja2cpp_error_info_to_string(error_info));
+        return 1;
+    }
+
+    jinja2cpp_values_map_t* tmpl_vars = jinja2cpp_values_map_create();
+    if (!tmpl_vars) {
+        fprintf(stderr, "Failed to create template variables\n");
+        return 1;
+    }
+
+    jinja2cpp_result_string_t* result_str = jinja2cpp_render_as_string(tmpl, tmpl_vars);
+    if (!jinja2cpp_result_has_value_string(result_str)) {
+        const jinja2cpp_error_info_t* error_info = jinja2cpp_result_error_string(result_str);
+        fprintf(stderr, "%s", jinja2cpp_error_info_to_string(error_info));
+        return 1;
+    }
+
+    printf("%s\n", jinja2cpp_result_value_string(result_str));
+
+    jinja2cpp_template_destroy(tmpl);
+    jinja2cpp_result_free_void(result);
+    jinja2cpp_result_free_string(result_str);
+    jinja2cpp_values_map_destroy(tmpl_vars);
+    
+    return 0;
+
+}

--- a/include/error_info_wrap.h
+++ b/include/error_info_wrap.h
@@ -2,15 +2,10 @@
 #define ERROR_INFO_WRAP_H
 
 #ifdef __cplusplus
-#include <jinja2cpp/error_info.h>
-#include <stddef.h>
-
-using jinja2cpp_error_info_t = jinja2::ErrorInfo;
 
 extern "C" {
 #endif
 
-// Определение кода ошибки
 typedef enum jinja2cpp_error_code_t {
     JINJA2CPP_ERROR_UNSPECIFIED = 0,
     JINJA2CPP_ERROR_UNEXPECTED_EXCEPTION = 1,
@@ -48,7 +43,6 @@ typedef enum jinja2cpp_error_code_t {
 } jinja2cpp_error_code_t;
 
 jinja2cpp_error_code_t jinja2cpp_error_info_get_code(const jinja2cpp_error_info_t* error_info);
-
 const char* jinja2cpp_error_info_to_string(const jinja2cpp_error_info_t* error_info);
 
 #ifdef __cplusplus

--- a/include/filesystem_handler_wrap.h
+++ b/include/filesystem_handler_wrap.h
@@ -1,23 +1,17 @@
-#ifndef FILE_SYSTEM_WRAP_H
-#define FILE_SYSTEM_WRAP_H
+#ifndef FILESYSTEM_HANDLER_WRAP_H
+#define FILESYSTEM_HANDLER_WRAP_H
 
 #ifdef __cplusplus
-#include <jinja2cpp/filesystem_handler.h>
-#include <stddef.h>
-
-using jinja2cpp_memory_file_system_t = jinja2::MemoryFileSystem;
 
 extern "C" {
 #endif
 
 jinja2cpp_memory_file_system_t* jinja2cpp_memory_file_system_create();
-
 void jinja2cpp_memory_file_system_destroy(jinja2cpp_memory_file_system_t* fs);
-
-void jinja2cpp_memory_file_system_add_file(jinja2cpp_memory_file_system_t* fs, const char* fileName, const char* fileContent);
+void jinja2cpp_memory_file_system_add_file(jinja2cpp_memory_file_system_t* fs, const char* name, const char* content);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // FILE_SYSTEM_WRAP_H
+#endif // FILESYSTEM_HANDLER_WRAP_H

--- a/include/jinja2cpp_wrap.h
+++ b/include/jinja2cpp_wrap.h
@@ -1,0 +1,66 @@
+#ifndef JINJA2CPP_WRAP_H
+#define JINJA2CPP_WRAP_H
+
+#include "jinja2cpp/template.h"
+#include <jinja2cpp/filesystem_handler.h>
+#include <jinja2cpp/template_env.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct jinja2cpp_error_info_t {
+    jinja2::ErrorInfo* ptr;
+} jinja2cpp_error_info_t;
+
+typedef struct jinja2cpp_memory_file_system_t {
+    jinja2::MemoryFileSystem* ptr;
+} jinja2cpp_memory_file_system_t;
+
+typedef struct jinja2cpp_result_void_t {
+    nonstd::expected<void, jinja2cpp_error_info_t>* ptr;
+} jinja2cpp_result_void_t;
+
+typedef struct jinja2cpp_result_string_t {
+    nonstd::expected<const char*, jinja2cpp_error_info_t>* ptr;
+} jinja2cpp_result_string_t;
+
+typedef struct jinja2cpp_result_template_t {
+    nonstd::expected<jinja2::Template, jinja2cpp_error_info_t>* ptr;
+} jinja2cpp_result_template_t;
+
+typedef struct jinja2cpp_value_t {
+    jinja2::Value* ptr;
+} jinja2cpp_value_t;
+
+typedef struct jinja2cpp_values_list_t {
+    jinja2::ValuesList* ptr;
+} jinja2cpp_values_list_t;
+
+typedef struct jinja2cpp_values_map_t {
+    jinja2::ValuesMap* ptr;
+} jinja2cpp_values_map_t;
+
+typedef struct jinja2cpp_template_env_t {
+    jinja2::TemplateEnv* ptr;
+} jinja2cpp_template_env_t;
+
+typedef struct jinja2cpp_template_t {
+    jinja2::Template* ptr;
+} jinja2cpp_template_t;
+
+#include "error_info_wrap.h"
+#include "filesystem_handler_wrap.h"
+#include "result_wrap.h"
+#include "value_wrap.h"
+#include "template_env_wrap.h"
+#include "template_wrap.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // JINJA2CPP_WRAP_H

--- a/include/result_wrap.h
+++ b/include/result_wrap.h
@@ -2,34 +2,25 @@
 #define RESULT_WRAP_H
 
 #ifdef __cplusplus
-#include "jinja2cpp/template.h"
-#include <nonstd/expected.hpp>
-#include "error_info_wrap.h"
-#include <stdbool.h>
-#include <stddef.h>
-
-using jinja2cpp_template_t = jinja2::Template;
-template <typename T>
-using jinja2cpp_result_t = nonstd::expected<T, jinja2cpp_error_info_t>;
 
 extern "C" {
 #endif
 
-void jinja2cpp_result_free_void(jinja2cpp_result_t<void>* result);
-void jinja2cpp_result_free_string(jinja2cpp_result_t<const char*>* result);
-void jinja2cpp_result_free_template(jinja2cpp_result_t<jinja2cpp_template_t*>* result);
+void jinja2cpp_result_free_void(jinja2cpp_result_void_t* result);
+void jinja2cpp_result_free_string(jinja2cpp_result_string_t* result);
+void jinja2cpp_result_free_template(jinja2cpp_result_template_t* result);
 
-bool jinja2cpp_result_has_value_void(const jinja2cpp_result_t<void>* result);
-bool jinja2cpp_result_has_value_string(const jinja2cpp_result_t<const char*>* result);
-bool jinja2cpp_result_has_value_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result);
+bool jinja2cpp_result_has_value_void(const jinja2cpp_result_void_t* result);
+bool jinja2cpp_result_has_value_string(const jinja2cpp_result_string_t* result);
+bool jinja2cpp_result_has_value_template(const jinja2cpp_result_template_t* result);
 
-const void jinja2cpp_result_value_void(const jinja2cpp_result_t<void>* result);
-const char* jinja2cpp_result_value_string(const jinja2cpp_result_t<const char*>* result);
-jinja2cpp_template_t* jinja2cpp_result_value_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result);
+void jinja2cpp_result_value_void(const jinja2cpp_result_void_t* result);
+const char* jinja2cpp_result_value_string(const jinja2cpp_result_string_t* result);
+jinja2cpp_template_t* jinja2cpp_result_value_template(const jinja2cpp_result_template_t* result);
 
-const jinja2cpp_error_info_t* jinja2cpp_result_error_void(const jinja2cpp_result_t<void>* result);
-const jinja2cpp_error_info_t* jinja2cpp_result_error_string(const jinja2cpp_result_t<const char*>* result);
-const jinja2cpp_error_info_t* jinja2cpp_result_error_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result);
+const jinja2cpp_error_info_t* jinja2cpp_result_error_void(const jinja2cpp_result_void_t* result);
+const jinja2cpp_error_info_t* jinja2cpp_result_error_string(const jinja2cpp_result_string_t* result);
+const jinja2cpp_error_info_t* jinja2cpp_result_error_template(const jinja2cpp_result_template_t* result);
 
 #ifdef __cplusplus
 }

--- a/include/template_env_wrap.h
+++ b/include/template_env_wrap.h
@@ -2,29 +2,21 @@
 #define TEMPLATE_ENV_WRAP_H 
 
 #ifdef __cplusplus
-#include <jinja2cpp/template_env.h>
-#include "filesystem_handler_wrap.h"
-#include "template_wrap.h"
-#include <stddef.h>
-#include <memory>
-#include <string>
-
-using jinja2cpp_template_env_t = jinja2::TemplateEnv;
 
 extern "C" {
 #endif
 
 jinja2cpp_template_env_t* jinja2cpp_template_env_create();
 
-void jinja2cpp_template_env_destroy(jinja2cpp_template_env_t* env);
+void jinja2cpp_template_env_destroy(jinja2cpp_template_env_t* tmpl_env);
 
-void jinja2cpp_template_env_add_filesystem_handler(jinja2cpp_template_env_t* env, const char* prefix, jinja2cpp_memory_file_system_t* handler);
+void jinja2cpp_template_env_add_filesystem_handler(jinja2cpp_template_env_t* tmpl_env, const char* prefix, jinja2cpp_memory_file_system_t* file_system);
 
-jinja2cpp_result_t<jinja2cpp_template_t*>* jinja2cpp_template_env_load_template(jinja2cpp_template_env_t* env, const char* fileName);
+jinja2cpp_result_template_t* jinja2cpp_template_env_load_template(jinja2cpp_template_env_t* tmpl_env, const char* file_name);
 
-void jinja2cpp_template_env_add_global(jinja2cpp_template_env_t* env, const char* name, jinja2cpp_value_t* value);
+void jinja2cpp_template_env_add_global(jinja2cpp_template_env_t* tmpl_env, const char* name, jinja2cpp_value_t* value);
 
-void jinja2cpp_template_env_remove_global(jinja2cpp_template_env_t* env, const char* name);
+void jinja2cpp_template_env_remove_global(jinja2cpp_template_env_t* tmpl_env, const char* name);
 
 #ifdef __cplusplus
 }

--- a/include/template_wrap.h
+++ b/include/template_wrap.h
@@ -2,24 +2,16 @@
 #define TEMPLATE_C_H
 
 #ifdef __cplusplus
-#include "jinja2cpp/template.h"
-#include "jinja2cpp/template_env.h"
-#include <stddef.h>
-#include "result_wrap.h"
-#include "value_wrap.h"
-
-using jinja2cpp_template_t = jinja2::Template;
-using jinja2cpp_template_env_t = jinja2::TemplateEnv;
 
 extern "C" {
 #endif
 
 jinja2cpp_template_t* jinja2cpp_template_create();
-jinja2cpp_template_t* jinja2cpp_template_create_template_env(jinja2cpp_template_env_t* env);
-void jinja2cpp_template_destroy(jinja2cpp_template_t* tpl);
+jinja2cpp_template_t* jinja2cpp_template_create_template_env(jinja2cpp_template_env_t* tmpl_env);
+void jinja2cpp_template_destroy(jinja2cpp_template_t* tmpl);
 
-jinja2cpp_result_t<void>* jinja2cpp_load(jinja2cpp_template_t* tpl, const char* src, const char* tpl_name);
-jinja2cpp_result_t<const char*>* jinja2cpp_render_as_string(jinja2cpp_template_t* tpl, const jinja2cpp_values_map_t* params);
+jinja2cpp_result_void_t* jinja2cpp_load(jinja2cpp_template_t* tmpl, const char* src, const char* tpl_name);
+jinja2cpp_result_string_t* jinja2cpp_render_as_string(jinja2cpp_template_t* tmpl, const jinja2cpp_values_map_t* tmpl_vars);
 
 #ifdef __cplusplus
 }

--- a/include/value_wrap.h
+++ b/include/value_wrap.h
@@ -2,20 +2,20 @@
 #define VALUE_WRAP_H
 
 #ifdef __cplusplus
-#include <jinja2cpp/value.h>
-#include <stddef.h>
-#include <stdbool.h>
-using jinja2cpp_value_t = jinja2::Value;
-using jinja2cpp_values_list_t = jinja2::ValuesList;
-using jinja2cpp_values_map_t = jinja2::ValuesMap;
 
 extern "C" {
 #endif
 
+jinja2cpp_values_map_t* jinja2cpp_values_map_create();
+void jinja2cpp_values_map_destroy(jinja2cpp_values_map_t* map);
+
+jinja2cpp_values_list_t* jinja2cpp_values_list_create();
+void jinja2cpp_values_list_destroy(jinja2cpp_values_list_t* list);
+
 jinja2cpp_value_t* jinja2cpp_value_create_empty();
-jinja2cpp_value_t* jinja2cpp_value_create_string(const char* val);
-jinja2cpp_value_t* jinja2cpp_value_create_int(int val);
-jinja2cpp_value_t* jinja2cpp_value_create_double(double val);
+jinja2cpp_value_t* jinja2cpp_value_create_string(const char* value);
+jinja2cpp_value_t* jinja2cpp_value_create_int(int value);
+jinja2cpp_value_t* jinja2cpp_value_create_double(double value);
 jinja2cpp_value_t* jinja2cpp_value_create_list(jinja2cpp_values_list_t* list);
 jinja2cpp_value_t* jinja2cpp_value_create_map(jinja2cpp_values_map_t* map);
 
@@ -30,14 +30,10 @@ const char* jinja2cpp_value_as_string(const jinja2cpp_value_t* value);
 jinja2cpp_values_list_t* jinja2cpp_value_as_list(jinja2cpp_value_t* value);
 jinja2cpp_values_map_t* jinja2cpp_value_as_map(jinja2cpp_value_t* value);
 
-jinja2cpp_values_map_t* jinja2cpp_values_map_create();
-void jinja2cpp_values_map_destroy(jinja2cpp_values_map_t* map);
 void jinja2cpp_values_map_set(jinja2cpp_values_map_t* map, const char* key, jinja2cpp_value_t* value);
 jinja2cpp_value_t* jinja2cpp_values_map_get(const jinja2cpp_values_map_t* map, const char* key);
 size_t jinja2cpp_values_map_size(const jinja2cpp_values_map_t* map);
 
-jinja2cpp_values_list_t* jinja2cpp_values_list_create();
-void jinja2cpp_values_list_destroy(jinja2cpp_values_list_t* list);
 void jinja2cpp_values_list_push(jinja2cpp_values_list_t* list, jinja2cpp_value_t* value);
 jinja2cpp_value_t* jinja2cpp_values_list_get(const jinja2cpp_values_list_t* list, size_t index);
 size_t jinja2cpp_values_list_size(const jinja2cpp_values_list_t* list);

--- a/src/error_info_wrap.cpp
+++ b/src/error_info_wrap.cpp
@@ -1,18 +1,16 @@
-#include "error_info_wrap.h"
-#include <string>
+#include "jinja2cpp_wrap.h"
 
 jinja2cpp_error_code_t jinja2cpp_error_info_get_code(const jinja2cpp_error_info_t* error_info) {
-    if (!error_info) {
+    if (!error_info || !error_info->ptr) {
         return JINJA2CPP_ERROR_UNSPECIFIED;
     }
-    return static_cast<jinja2cpp_error_code_t>(error_info->GetCode());
+    return static_cast<jinja2cpp_error_code_t>(error_info->ptr->GetCode());
 }
 
 const char* jinja2cpp_error_info_to_string(const jinja2cpp_error_info_t* error_info) {
-    if (!error_info) {
+    if (!error_info || !error_info->ptr) {
         return "Unknown error";
     }
-    thread_local std::string error_message;
-    error_message = error_info->ToString();
+    thread_local std::string error_message = error_info->ptr->ToString();
     return error_message.c_str();
 }

--- a/src/filesystem_handler_wrap.cpp
+++ b/src/filesystem_handler_wrap.cpp
@@ -1,14 +1,18 @@
-#include "filesystem_handler_wrap.h"
+#include "jinja2cpp_wrap.h"
 
 jinja2cpp_memory_file_system_t* jinja2cpp_memory_file_system_create() {
-    return new jinja2cpp_memory_file_system_t();
+    jinja2cpp_memory_file_system_t* fs = new jinja2cpp_memory_file_system_t();
+    fs->ptr = new jinja2::MemoryFileSystem();
+    return fs;
 }
 
 void jinja2cpp_memory_file_system_destroy(jinja2cpp_memory_file_system_t* fs) {
+    if (!fs || !fs->ptr) return;
+    delete fs->ptr;
     delete fs;
 }
 
-void jinja2cpp_memory_file_system_add_file(jinja2cpp_memory_file_system_t* fs, const char* fileName, const char* fileContent) {
-    if (!fs || !fileName || !fileContent) return;
-    fs->AddFile(fileName, fileContent);
+void jinja2cpp_memory_file_system_add_file(jinja2cpp_memory_file_system_t* fs, const char* name, const char* content) {
+    if (!fs || !fs->ptr || !name || !content) return;
+    fs->ptr->AddFile(name, content);
 }

--- a/src/result_wrap.cpp
+++ b/src/result_wrap.cpp
@@ -1,64 +1,64 @@
-#include "result_wrap.h"
+#include "jinja2cpp_wrap.h"
 
-void jinja2cpp_result_free_void(jinja2cpp_result_t<void>* result) {
+void jinja2cpp_result_free_void(jinja2cpp_result_void_t* result) {
+    if (!result || !result->ptr) return;
+    delete result->ptr;
     delete result;
 }
 
-void jinja2cpp_result_free_string(jinja2cpp_result_t<const char*>* result) {
-    if (!result) return;
-    if (result->has_value()) {
-        free(const_cast<char*>(result->value()));
+void jinja2cpp_result_free_string(jinja2cpp_result_string_t* result) {
+    if (!result || !result->ptr) return;
+    if (result->ptr->has_value()) {
+        free(const_cast<char*>(result->ptr->value()));
     }
+    delete result->ptr;
     delete result;
 }
 
-void jinja2cpp_result_free_template(jinja2cpp_result_t<jinja2cpp_template_t*>* result) {
+void jinja2cpp_result_free_template(jinja2cpp_result_template_t* result) {
+    if (!result || !result->ptr) return;
+    delete result->ptr;
     delete result;
 }
 
-bool jinja2cpp_result_has_value_void(const jinja2cpp_result_t<void>* result) {
-    return result && result->has_value();
+bool jinja2cpp_result_has_value_void(const jinja2cpp_result_void_t* result) {
+    return result && result->ptr && result->ptr->has_value();
 }
 
-bool jinja2cpp_result_has_value_string(const jinja2cpp_result_t<const char*>* result) {
-    return result && result->has_value();
+bool jinja2cpp_result_has_value_string(const jinja2cpp_result_string_t* result) {
+    return result && result->ptr && result->ptr->has_value();
 }
 
-bool jinja2cpp_result_has_value_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result) {
-    return result && result->has_value();
+bool jinja2cpp_result_has_value_template(const jinja2cpp_result_template_t* result) {
+    return result && result->ptr && result->ptr->has_value();
 }
 
-const void jinja2cpp_result_value_void(const jinja2cpp_result_t<void>* result) {
-    if (!result || !result->has_value()) return;
-    return result->value();
+void jinja2cpp_result_value_void(const jinja2cpp_result_void_t* result) {
+    if (!result || !result->ptr || !result->ptr->has_value()) return;
 }
 
-const char* jinja2cpp_result_value_string(const jinja2cpp_result_t<const char*>* result) {
-    return (result && result->has_value()) ? result->value() : nullptr;
+const char* jinja2cpp_result_value_string(const jinja2cpp_result_string_t* result) {
+    return (result && result->ptr && result->ptr->has_value()) ? result->ptr->value() : nullptr;
 }
 
-jinja2cpp_template_t* jinja2cpp_result_value_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result) {
-    if (!result || !result->has_value()) return nullptr;
-    return result->value();
+jinja2cpp_template_t* jinja2cpp_result_value_template(const jinja2cpp_result_template_t* result) {
+    if (!result || !result->ptr || !result->ptr->has_value()) return nullptr;
+    jinja2cpp_template_t* wrapper = new jinja2cpp_template_t;
+    wrapper->ptr = &(result->ptr->value());
+    return wrapper;
 }
 
-const jinja2cpp_error_info_t* jinja2cpp_result_error_void(const jinja2cpp_result_t<void>* result) {
-    if (!result || result->has_value()) return nullptr;
-    static jinja2cpp_error_info_t temp_error;
-    temp_error = result->error();
-    return &temp_error;
+const jinja2cpp_error_info_t* jinja2cpp_result_error_void(const jinja2cpp_result_void_t* result) {
+    if (!result || !result->ptr || result->ptr->has_value()) return nullptr;
+    return new jinja2cpp_error_info_t(result->ptr->error());
 }
 
-const jinja2cpp_error_info_t* jinja2cpp_result_error_string(const jinja2cpp_result_t<const char*>* result) {
-    if (!result || result->has_value()) return nullptr;
-    static jinja2cpp_error_info_t temp_error;
-    temp_error = result->error();
-    return &temp_error;
+const jinja2cpp_error_info_t* jinja2cpp_result_error_string(const jinja2cpp_result_string_t* result) {
+    if (!result || !result->ptr || result->ptr->has_value()) return nullptr;
+    return new jinja2cpp_error_info_t(result->ptr->error());
 }
 
-const jinja2cpp_error_info_t* jinja2cpp_result_error_template(const jinja2cpp_result_t<jinja2cpp_template_t*>* result) {
-    if (!result || result->has_value()) return nullptr;
-    static jinja2cpp_error_info_t temp_error;
-    temp_error = result->error();
-    return &temp_error;
+const jinja2cpp_error_info_t* jinja2cpp_result_error_template(const jinja2cpp_result_template_t* result) {
+    if (!result || !result->ptr || result->ptr->has_value()) return nullptr;
+    return new jinja2cpp_error_info_t(result->ptr->error());
 }

--- a/src/template_env_wrap.cpp
+++ b/src/template_env_wrap.cpp
@@ -1,41 +1,52 @@
-#include "template_env_wrap.h"
+#include "jinja2cpp_wrap.h"
 
 jinja2cpp_template_env_t* jinja2cpp_template_env_create() {
-    return new jinja2cpp_template_env_t();
+    return new jinja2cpp_template_env_t{ new jinja2::TemplateEnv() };
 }
 
-void jinja2cpp_template_env_destroy(jinja2cpp_template_env_t* env) {
-    delete env;
+void jinja2cpp_template_env_destroy(jinja2cpp_template_env_t* tmpl_env) {
+    if (!tmpl_env || !tmpl_env->ptr) return;
+    delete tmpl_env->ptr;
+    delete tmpl_env;
 }
 
-// void jinja2cpp_template_env_add_filesystem_handler(jinja2cpp_template_env_t* env, const char* prefix, jinja2cpp_memory_file_system_t* handler) {
-//     if (!env || !prefix || !handler) return;
-//     env->AddFilesystemHandler(prefix, std::shared_ptr<jinja2cpp_memory_file_system_t>(handler));
-// }
-
-void jinja2cpp_template_env_add_filesystem_handler(jinja2cpp_template_env_t* env, const char* prefix, jinja2cpp_memory_file_system_t* handler) {
-    if (!env || !prefix || !handler) return;
-    env->AddFilesystemHandler(std::string(prefix), *handler);
+void jinja2cpp_template_env_add_filesystem_handler(jinja2cpp_template_env_t* tmpl_env, const char* prefix, jinja2cpp_memory_file_system_t* file_system) {
+    if (!tmpl_env || !tmpl_env->ptr || !prefix || !file_system || !file_system->ptr) return;
+    tmpl_env->ptr->AddFilesystemHandler(std::string(prefix), *file_system->ptr);
 }
 
-jinja2cpp_result_t<jinja2cpp_template_t*>* jinja2cpp_template_env_load_template(jinja2cpp_template_env_t* env, const char* fileName) {
-    if (!env || !fileName) {
-        return new jinja2cpp_result_t<jinja2cpp_template_t*>(nonstd::make_unexpected(jinja2cpp_error_info_t()));
+jinja2cpp_result_template_t* jinja2cpp_template_env_load_template(jinja2cpp_template_env_t* tmpl_env, const char* file_name) {
+    if (!tmpl_env || !tmpl_env->ptr || !file_name) {
+        return new jinja2cpp_result_template_t{
+            new nonstd::expected<jinja2::Template, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(jinja2cpp_error_info_t{nullptr})
+            )
+        };
     }
-    auto templateResult = env->LoadTemplate(fileName);
+
+    auto templateResult = tmpl_env->ptr->LoadTemplate(file_name);
     if (!templateResult.has_value()) {
-        return new jinja2cpp_result_t<jinja2cpp_template_t*>(nonstd::make_unexpected(templateResult.error()));
+        auto* error_info = new jinja2::ErrorInfoTpl<char>(templateResult.error());
+        return new jinja2cpp_result_template_t{
+            new nonstd::expected<jinja2::Template, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(jinja2cpp_error_info_t{error_info})
+            )
+        };
     }
 
-    return new jinja2cpp_result_t<jinja2cpp_template_t*>(new jinja2cpp_template_t(std::move(templateResult.value())));
+    return new jinja2cpp_result_template_t{
+        new nonstd::expected<jinja2::Template, jinja2cpp_error_info_t>(
+            std::move(templateResult.value())
+        )
+    };
 }
 
-void jinja2cpp_template_env_add_global(jinja2cpp_template_env_t* env, const char* name, jinja2cpp_value_t* value) {
-    if (!env || !name || !value) return;
-    env->AddGlobal(name, *value);
+void jinja2cpp_template_env_add_global(jinja2cpp_template_env_t* tmpl_env, const char* name, jinja2cpp_value_t* value) {
+    if (!tmpl_env || !tmpl_env->ptr || !name || !value || !value->ptr) return;
+    tmpl_env->ptr->AddGlobal(name, *value->ptr);
 }
 
-void jinja2cpp_template_env_remove_global(jinja2cpp_template_env_t* env, const char* name) {
-    if (!env || !name) return;
-    env->RemoveGlobal(name);
+void jinja2cpp_template_env_remove_global(jinja2cpp_template_env_t* tmpl_env, const char* name) {
+    if (!tmpl_env || !tmpl_env->ptr || !name) return;
+    tmpl_env->ptr->RemoveGlobal(name);
 }

--- a/src/template_wrap.cpp
+++ b/src/template_wrap.cpp
@@ -1,35 +1,65 @@
-#include "template_wrap.h"
-#include <cstring>
+#include "jinja2cpp_wrap.h"
 
 jinja2cpp_template_t* jinja2cpp_template_create() {
-    return new jinja2cpp_template_t();
+    return new jinja2cpp_template_t{ new jinja2::Template() };
 }
 
-jinja2cpp_template_t* jinja2cpp_template_create_template_env(jinja2cpp_template_env_t* env) {
-    return new jinja2cpp_template_t(env);
+jinja2cpp_template_t* jinja2cpp_template_create_template_env(jinja2cpp_template_env_t* tmpl_env) {
+    return new jinja2cpp_template_t{ new jinja2::Template(tmpl_env->ptr)};
 }
 
-void jinja2cpp_template_destroy(jinja2cpp_template_t* tpl) {
-    delete tpl;
+void jinja2cpp_template_destroy(jinja2cpp_template_t* tmpl) {
+    if (!tmpl || !tmpl->ptr) return;
+    delete tmpl->ptr;
+    delete tmpl;
 }
 
-jinja2cpp_result_t<void>* jinja2cpp_load(jinja2cpp_template_t* tpl, const char* src, const char* tpl_name) {
-    if (!tpl || !src) {
-        return new jinja2cpp_result_t<void>(nonstd::make_unexpected(jinja2cpp_error_info_t()));
+jinja2cpp_result_void_t* jinja2cpp_load(jinja2cpp_template_t* tmpl, const char* src, const char* tpl_name) {
+    if (!tmpl || !tmpl->ptr || !src) {
+        return new jinja2cpp_result_void_t{
+            new nonstd::expected<void, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(jinja2cpp_error_info_t{nullptr})
+            )
+        };
     }
-    return new jinja2cpp_result_t<void>(tpl->Load(src, tpl_name ? std::string(tpl_name) : std::string()));
+
+    auto result = tmpl->ptr->Load(src, tpl_name ? std::string(tpl_name) : std::string());
+    if (!result.has_value()) {
+        jinja2cpp_error_info_t error_info{ new jinja2::ErrorInfoTpl<char>(result.error()) };
+
+        return new jinja2cpp_result_void_t{
+            new nonstd::expected<void, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(std::move(error_info))
+            )
+        };
+    }
+
+    return new jinja2cpp_result_void_t{ new nonstd::expected<void, jinja2cpp_error_info_t>() };
 }
 
-jinja2cpp_result_t<const char*>* jinja2cpp_render_as_string(jinja2cpp_template_t* tpl, const jinja2cpp_values_map_t* params) {
-    if (!tpl || !params) {
-        return new jinja2cpp_result_t<const char*>(nonstd::make_unexpected(jinja2cpp_error_info_t()));
+jinja2cpp_result_string_t* jinja2cpp_render_as_string(jinja2cpp_template_t* tmpl, const jinja2cpp_values_map_t* tmpl_vars) {
+    if (!tmpl || !tmpl->ptr || !tmpl_vars) {
+        return new jinja2cpp_result_string_t{
+            new nonstd::expected<const char*, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(jinja2cpp_error_info_t{nullptr})
+            )
+        };
     }
 
-    auto result = tpl->RenderAsString(*params);
-    if (result.has_value()) {
-        char* result_cstr = strdup(result->c_str());
-        return new jinja2cpp_result_t<const char*>(result_cstr);
-    } else {
-        return new jinja2cpp_result_t<const char*>(nonstd::make_unexpected(result.error()));
+    auto result = tmpl->ptr->RenderAsString(*tmpl_vars->ptr);
+
+    if (!result.has_value()) {
+        jinja2cpp_error_info_t error_info{ new jinja2::ErrorInfoTpl<char>(result.error()) };
+
+        return new jinja2cpp_result_string_t{
+            new nonstd::expected<const char*, jinja2cpp_error_info_t>(
+                nonstd::unexpected<jinja2cpp_error_info_t>(std::move(error_info))
+            )
+        };
     }
+
+    char* result_cstr = strdup(result->c_str());
+    return new jinja2cpp_result_string_t{
+        new nonstd::expected<const char*, jinja2cpp_error_info_t>(result_cstr)
+    };
 }

--- a/src/value_wrap.cpp
+++ b/src/value_wrap.cpp
@@ -1,109 +1,142 @@
-#include "value_wrap.h"
-#include <string>
+#include "jinja2cpp_wrap.h"
 
-jinja2cpp_value_t* jinja2cpp_value_create_empty() { return new jinja2cpp_value_t(); }
-jinja2cpp_value_t* jinja2cpp_value_create_string(const char* val) { return new jinja2cpp_value_t(val ? val : ""); }
-jinja2cpp_value_t* jinja2cpp_value_create_int(int val) {return new jinja2cpp_value_t(val); }
-jinja2cpp_value_t* jinja2cpp_value_create_double(double val) {return new jinja2cpp_value_t(val); }
-jinja2cpp_value_t* jinja2cpp_value_create_list(jinja2cpp_values_list_t* list) { 
-    if (!list) return nullptr;
-    auto* value = new jinja2cpp_value_t(std::move(*list));
+jinja2cpp_values_map_t* jinja2cpp_values_map_create() { 
+    return new jinja2cpp_values_map_t{ new jinja2::ValuesMap() }; 
+}
+
+void jinja2cpp_values_map_destroy(jinja2cpp_values_map_t* map) {
+    if (!map || !map->ptr) return;
+
+    map->ptr->clear();
+    delete map->ptr;
+    delete map;
+}
+
+jinja2cpp_values_list_t* jinja2cpp_values_list_create() { 
+    return new jinja2cpp_values_list_t{ new jinja2::ValuesList() }; 
+}
+
+void jinja2cpp_values_list_destroy(jinja2cpp_values_list_t* list) {
+    if (!list || !list->ptr) return;
+
+    list->ptr->clear(); 
+    delete list->ptr;
     delete list;
-    return value;
+}
+
+jinja2cpp_value_t* jinja2cpp_value_create_empty() { 
+    return new jinja2cpp_value_t{ new jinja2::Value() }; 
+}
+
+jinja2cpp_value_t* jinja2cpp_value_create_string(const char* value) { 
+    return new jinja2cpp_value_t{ new jinja2::Value(value ? value : "") }; 
+}
+
+jinja2cpp_value_t* jinja2cpp_value_create_int(int value) {
+    return new jinja2cpp_value_t{ new jinja2::Value(value) }; 
+}
+
+jinja2cpp_value_t* jinja2cpp_value_create_double(double value) {
+    return new jinja2cpp_value_t{ new jinja2::Value(value) }; 
+}
+
+jinja2cpp_value_t* jinja2cpp_value_create_list(jinja2cpp_values_list_t* list) { 
+    if (!list || !list->ptr) return nullptr;
+
+    auto* value = new jinja2::Value(std::move(*list->ptr));
+    jinja2cpp_values_list_destroy(list);
+    return new jinja2cpp_value_t{ value };
 }
 
 jinja2cpp_value_t* jinja2cpp_value_create_map(jinja2cpp_values_map_t* map) { 
-    if (!map) return nullptr;
-    auto* value = new jinja2cpp_value_t(std::move(*map));
-    delete map;
-    return value;
+    if (!map || !map->ptr) return nullptr;
+
+    auto* value = new jinja2::Value(std::move(*map->ptr));
+    jinja2cpp_values_map_destroy(map);
+    return new jinja2cpp_value_t{ value };
 }
 
-void jinja2cpp_value_destroy(jinja2cpp_value_t* value) { delete static_cast<jinja2cpp_value_t*>(value); }
+void jinja2cpp_value_destroy(jinja2cpp_value_t* value) { 
+    if (!value || !value->ptr) return;
+
+    delete value->ptr;
+    delete value;
+}
 
 bool jinja2cpp_value_is_string(const jinja2cpp_value_t* value) {
-    if (!value) return false;
-    return static_cast<const jinja2cpp_value_t*>(value)->isString();
+    if (!value || !value->ptr) return false;
+
+    return static_cast<const jinja2cpp_value_t*>(value)->ptr->isString();
 }
 
 bool jinja2cpp_value_is_list(const jinja2cpp_value_t* value) {
-    if (!value) return false;
-    return static_cast<const jinja2cpp_value_t*>(value)->isList();
+    if (!value || !value->ptr) return false;
+
+    return static_cast<const jinja2cpp_value_t*>(value)->ptr->isList();
 }
 
 bool jinja2cpp_value_is_map(const jinja2cpp_value_t* value) {
-    if (!value) return false;
-    return static_cast<const jinja2cpp_value_t*>(value)->isMap();
+    if (!value || !value->ptr) return false;
+
+    return static_cast<const jinja2cpp_value_t*>(value)->ptr->isMap();
 }
 
 bool jinja2cpp_value_is_empty(const jinja2cpp_value_t* value) {
-    if (!value) return false;
-    return static_cast<const jinja2cpp_value_t*>(value)->isEmpty();
+    if (!value || !value->ptr) return false;
+
+    return static_cast<const jinja2cpp_value_t*>(value)->ptr->isEmpty();
 }
 
 const char* jinja2cpp_value_as_string(const jinja2cpp_value_t* value) {
-    if (!value || !value->isString()) return nullptr;
-    return value->asString().c_str();
+    if (!value || !value->ptr || !value->ptr->isString()) return nullptr;
+
+    return value->ptr->asString().c_str();
 }
 
 jinja2cpp_values_list_t* jinja2cpp_value_as_list(jinja2cpp_value_t* value) {
-    if (!value || !static_cast<const jinja2cpp_value_t*>(value)->isList()) return nullptr;
-    return &static_cast<jinja2cpp_value_t*>(value)->asList();
+    if (!value || !value->ptr) return nullptr;
+
+    return new jinja2cpp_values_list_t{ new std::vector<jinja2::Value>(value->ptr->asList()) };
 }
 
 jinja2cpp_values_map_t* jinja2cpp_value_as_map(jinja2cpp_value_t* value) {
-    if (!value || !static_cast<const jinja2cpp_value_t*>(value)->isMap()) return nullptr;
-    return &static_cast<jinja2cpp_value_t*>(value)->asMap();
-}
+    if (!value || !value->ptr) return nullptr;
 
-jinja2cpp_values_map_t* jinja2cpp_values_map_create() { return new jinja2cpp_values_map_t(); }
-void jinja2cpp_values_map_destroy(jinja2cpp_values_map_t* map) {
-    if (!map) return;
-    
-    map->clear();
-    
-    delete map;
+    return new jinja2cpp_values_map_t{ new jinja2::ValuesMap(value->ptr->asMap()) };
 }
 
 void jinja2cpp_values_map_set(jinja2cpp_values_map_t* map, const char* key, jinja2cpp_value_t* value) {
-    if (!map || !key || !value) return;
-    (*map)[key] = std::move(*value);
+    if (!map || !map->ptr || !key || !value || !value->ptr) return;
+    (*map->ptr)[key] = std::move(*value->ptr);
     jinja2cpp_value_destroy(value);
 }
 
 jinja2cpp_value_t* jinja2cpp_values_map_get(const jinja2cpp_values_map_t* map, const char* key) {
-    if (!map || !key) return nullptr;
+    if (!map || !map->ptr || !key) return nullptr;
     
-    auto it = map->find(key);
-    if (it == map->end()) return nullptr;
+    auto it = map->ptr->find(key);
+    if (it == map->ptr->end()) return nullptr;
 
-    return new jinja2cpp_value_t(it->second);
+    return new jinja2cpp_value_t{ new jinja2::Value(it->second) };
 }
 
 size_t jinja2cpp_values_map_size(const jinja2cpp_values_map_t* map) {
-    return map ? map->size() : 0;
-}
-
-jinja2cpp_values_list_t* jinja2cpp_values_list_create() { return new jinja2cpp_values_list_t(); }
-void jinja2cpp_values_list_destroy(jinja2cpp_values_list_t* list) {
-    if (!list) return;
-
-    list->clear(); 
-    delete list;
+    return (map && map->ptr) ? map->ptr->size() : 0;
 }
 
 void jinja2cpp_values_list_push(jinja2cpp_values_list_t* list, jinja2cpp_value_t* value) {
-    if (!list || !value) return;
-    list->push_back(std::move(*value));
+    if (!list || !list->ptr || !value || !value->ptr) return;
+
+    list->ptr->push_back(std::move(*value->ptr));
     jinja2cpp_value_destroy(value);
-    value = nullptr;
 }
 
 jinja2cpp_value_t* jinja2cpp_values_list_get(const jinja2cpp_values_list_t* list, size_t index) {
-    if (!list || index >= list->size()) return nullptr;
-    return new jinja2cpp_value_t((*list)[index]);
+    if (!list || !list->ptr || index >= list->ptr->size()) return nullptr;
+    
+    return new jinja2cpp_value_t{ new jinja2::Value((*list->ptr)[index]) };
 }
 
 size_t jinja2cpp_values_list_size(const jinja2cpp_values_list_t* list) {
-    return list ? list->size() : 0;
+    return (list && list->ptr) ? list->ptr->size() : 0;
 }


### PR DESCRIPTION
- Introduced a main header file (`jinja2cpp_wrap.h`) for the C API;
- Removed `using` and added wrappers for Jinja2Cpp types;
- Improved `CMakeLists.txt` for header installation;
- Added a usage example;
